### PR TITLE
feat: support split Markdown tests, close #84

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,23 @@ This package includes a JS/CoffeeScript/Markdown preprocessor that can find and 
 
 See example [bahmutov/vuepress-cypress-test-example](https://github.com/bahmutov/vuepress-cypress-test-example) and [live site](https://vuepress-cypress-test-example.netlify.com/). Read blog posts [Run End-to-end Tests from Markdown Files](https://glebbahmutov.com/blog/cypress-fiddle/) and [Self-testing JAM pages](https://www.cypress.io/blog/2019/11/13/self-testing-jam-pages/).
 
+You can have common HTML block and split the test across multiple JavaScript code blocks. This is useful to explain the test step by step
+
+    This test has multiple parts. First, it confirms the string value
+    ```js
+    cy.wrap('first').should('equal', 'first')
+    ```
+    Then it checks if 42 is 42
+    ```js
+    cy.wrap(42).should('equal', 42)
+    ```
+
+The actual test to be executed will be
+```js
+cy.wrap('first').should('equal', 'first')
+cy.wrap(42).should('equal', 42)
+```
+
 ### Hiding fiddle in Markdown
 
 You can "hide" fiddle inside Markdown so the page _can test itself_. See [cypress/integration/hidden-fiddle.md](cypress/integration/hidden-fiddle.md) example.

--- a/cypress/integration/contains-example.md
+++ b/cypress/integration/contains-example.md
@@ -29,3 +29,30 @@ cy.get('#app').should('be.visible')
 ```
 
 <!-- fiddle-end -->
+
+<!-- fiddle split fiddle -->
+This fiddle has common HTML code
+
+```html
+<div id="app">nothing here</div>
+<script>
+setTimeout(() => {
+  document.getElementById('app').innerText = 'something'
+}, 2000)
+</script>
+```
+
+Then first assertion
+
+```js
+cy.contains('#app', 'something')
+```
+
+Then more test code here
+
+```js
+// this command will only run AFTER cy.contains finishes
+cy.get('#app').should('be.visible')
+```
+
+<!-- fiddle-end -->

--- a/src/markdown-preprocessor.js
+++ b/src/markdown-preprocessor.js
@@ -93,12 +93,17 @@ const mdPreprocessor = file => {
     // console.log('found html block?', htmlMaybe)
     const isJavaScript = n =>
       n.type === 'CodeBlock' && (n.lang === 'js' || n.lang === 'javascript')
-    const jsMaybe = ast.children.find(isJavaScript)
+
+    // a single fiddle can have multiple JS blocks
+    // we want to find them all and merge into a single test
+    const jsMaybe = ast.children.filter(isJavaScript)
+    console.log('js blocks', jsMaybe)
     // console.log('found js block?', jsMaybe)
-    if (jsMaybe) {
+    if (jsMaybe.length) {
+      const testCode = jsMaybe.map(b => b.value).join('\n')
       testFiddles.push({
         name: fiddle.name,
-        test: jsMaybe.value,
+        test: testCode,
         html: htmlMaybe ? htmlMaybe.value : null
       })
     }


### PR DESCRIPTION
- closes #84

You can have common HTML block and split the test across multiple JavaScript code blocks. This is useful to explain the test step by step

    This test has multiple parts. First, it confirms the string value
    ```js
    cy.wrap('first').should('equal', 'first')
    ```
    Then it checks if 42 is 42
    ```js
    cy.wrap(42).should('equal', 42)
    ```

The actual test to be executed will be
```js
cy.wrap('first').should('equal', 'first')
cy.wrap(42).should('equal', 42)
```