### PR TITLE
feat: add skip and only support to fiddles

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ cy.wrap('first').should('equal', 'first')
 cy.wrap(42).should('equal', 42)
 ```
 
+### Skip and only
+
+You can skip a fiddle, or run only a particular fiddle similar to `it.skip` and `it.only`
+
+```
+<!-- fiddle.skip this is a skipped test -->
+<!-- fiddle.only this is an exclusive test -->
+```
+
 ### Hiding fiddle in Markdown
 
 You can "hide" fiddle inside Markdown so the page _can test itself_. See [cypress/integration/hidden-fiddle.md](cypress/integration/hidden-fiddle.md) example.

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ const testExamples = maybeTest => {
   }
 
   if (Array.isArray(maybeTest)) {
-    console.log('list of tests')
+    // console.log('list of tests')
     maybeTest.forEach(test => {
       createTest(test.name, test)
     })
@@ -133,10 +133,10 @@ const testExamples = maybeTest => {
   }
 
   forEach(maybeTest, (value, name) => {
-    console.log({ name, value })
+    // console.log({ name, value })
 
     if (isTestObject(value)) {
-      console.log('%s is a test', name)
+      // console.log('%s is a test', name)
 
       if (value.skip && value.only) {
         throw new Error(`Test ${name} has `)
@@ -147,7 +147,7 @@ const testExamples = maybeTest => {
     }
 
     // final choice - create nested suite of tests
-    console.log('creating new suite "%s"', name)
+    // console.log('creating new suite "%s"', name)
     describe(name, () => {
       testExamples(value)
     })


### PR DESCRIPTION
- closes #25 

You can skip a fiddle, or run only a particular fiddle similar to `it.skip` and `it.only`

```
<!-- fiddle.skip this is a skipped test -->
<!-- fiddle.only this is an exclusive test -->
```