### PR TITLE
feat: support live html blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,34 @@ describe('<some text>', () => {
 })
 ```
 
+### Live HTML
+
+You can include "live" html blocks in the fiddle - in that case they will become the test fragment.
+
+    <!-- fiddle includes live html -->
+    <div id="live-block">Live Block</div>
+    ```js
+    cy.contains('#live-block', 'Live Block').should('be.visible')
+    ```
+    <!-- fiddle-end -->
+
+When including HTML source fragment and live HTML block, live HTML block wins and will be used as the test fragment.
+
+    <!-- fiddle includes both live and html block -->
+    ```html
+    <div id="my-block">Block</div>
+    ```
+
+    <div id="live-block">Live Block</div>
+
+    ```js
+    // when including both live HTML block and
+    // html code block, the live HTML block wins
+    cy.contains('#live-block', 'Live Block').should('be.visible')
+    cy.contains('#my-block', 'Block').should('not.exist')
+    ```
+    <!-- fiddle-end -->
+
 ### Hiding fiddle in Markdown
 
 You can "hide" fiddle inside Markdown so the page _can test itself_. See [cypress/integration/hidden-fiddle.md](cypress/integration/hidden-fiddle.md) example.

--- a/cypress/integration/live-html.md
+++ b/cypress/integration/live-html.md
@@ -1,0 +1,34 @@
+# Live HTML
+
+<!-- fiddle includes live html -->
+
+<div id="live-block">Live Block</div>
+
+```js
+cy.contains('#live-block', 'Live Block').should('be.visible')
+```
+<!-- fiddle-end -->
+
+<!-- fiddle includes html block -->
+```html
+<div id="my-block">Block</div>
+```
+```js
+cy.contains('#my-block', 'Block').should('be.visible')
+```
+<!-- fiddle-end -->
+
+<!-- fiddle includes both live and html block -->
+```html
+<div id="my-block">Block</div>
+```
+
+<div id="live-block">Live Block</div>
+
+```js
+// when including both live HTML block and
+// html code block, the live HTML block wins
+cy.contains('#live-block', 'Live Block').should('be.visible')
+cy.contains('#my-block', 'Block').should('not.exist')
+```
+<!-- fiddle-end -->

--- a/src/markdown-preprocessor.js
+++ b/src/markdown-preprocessor.js
@@ -1,3 +1,4 @@
+// @ts-check
 const fs = require('fs')
 const path = require('path')
 const { source } = require('common-tags')
@@ -111,8 +112,11 @@ const mdPreprocessor = file => {
     const ast = parse(fiddle.fiddle)
     // console.log('markdown fiddle AST')
     // console.log(ast)
-    const htmlMaybe = ast.children.find(
+    const htmlCodeBlockMaybe = ast.children.find(
       n => n.type === 'CodeBlock' && n.lang === 'html'
+    )
+    const htmlLiveBlockMaybe = ast.children.find(
+      n => n.type === 'Html'
     )
     // console.log('found html block?', htmlMaybe)
     const isJavaScript = n =>
@@ -124,10 +128,13 @@ const mdPreprocessor = file => {
 
     if (jsMaybe.length) {
       const testCode = jsMaybe.map(b => b.value).join('\n')
+
+      const htmlNode = htmlLiveBlockMaybe || htmlCodeBlockMaybe
+
       testFiddles.push({
         name: fiddle.name,
         test: testCode,
-        html: htmlMaybe ? htmlMaybe.value : null,
+        html: htmlNode ? htmlNode.value : null,
         only: fiddle.only,
         skip: fiddle.skip
       })


### PR DESCRIPTION
You can include "live" html blocks in the fiddle - in that case, they will become the test fragment.

    <!-- fiddle includes live html -->
    <div id="live-block">Live Block</div>
    ```js
    cy.contains('#live-block', 'Live Block').should('be.visible')
    ```
    <!-- fiddle-end -->

If you include both "live" HTML block and HTML source code block, the live block wins and is used in the test.