### PR TITLE
fix: wrap eval in function to handle return statement

### DIFF
--- a/cypress/integration/return-example.md
+++ b/cypress/integration/return-example.md
@@ -1,0 +1,10 @@
+A test with `return` statement
+
+<!-- fiddle with return -->
+```js
+expect(2).to.equal(2)
+if (true) {
+  return
+}
+```
+<!-- fiddle-end -->

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,8 @@ Cypress.Commands.add('runExample', options => {
       // because in that case we should not use "cy.within" or mount html
     }
     cy.get('#live', noLog).within(noLog, () => {
-      eval(test)
+      const insideFunction = '(function live() {;' + test + '})()'
+      eval(insideFunction)
     })
   } else {
     if (html) {

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ Cypress.Commands.add('runExample', options => {
       // because in that case we should not use "cy.within" or mount html
     }
     cy.get('#live', noLog).within(noLog, () => {
-      const insideFunction = '(function live() {\n' + test + '\n})()'
+      const insideFunction = '(function live() {\n' + test + '\n}).call(this)'
       eval(insideFunction)
     })
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,7 @@ Cypress.Commands.add('runExample', options => {
       // because in that case we should not use "cy.within" or mount html
     }
     cy.get('#live', noLog).within(noLog, () => {
-      const insideFunction = '(function live() {;' + test + '})()'
+      const insideFunction = '(function live() {\n' + test + '\n})()'
       eval(insideFunction)
     })
   } else {


### PR DESCRIPTION
Test in Markdown fiddle

```js
expect(2).to.equal(2)
if (true) {
  return
}
```

Before

<img width="697" alt="Screen Shot 2020-05-05 at 4 30 19 PM" src="https://user-images.githubusercontent.com/2212006/81113295-fbbbbe80-8eed-11ea-9859-c058f18a68a8.png">

After

<img width="696" alt="Screen Shot 2020-05-05 at 4 31 04 PM" src="https://user-images.githubusercontent.com/2212006/81113303-00807280-8eee-11ea-9b49-fb25a6c9ca10.png">
