### PR TITLE
fix: empty test block in markdown test should not fail the test

### DIFF
--- a/cypress/integration/dynamic-select.md
+++ b/cypress/integration/dynamic-select.md
@@ -1,0 +1,13 @@
+Example where a `<select>` element gets dynamic list
+
+<!-- fiddle -->
+
+```html
+<select id="my-select"></select>
+```
+
+```js
+
+```
+
+<!-- fiddle-end -->

--- a/cypress/integration/dynamic-select.md
+++ b/cypress/integration/dynamic-select.md
@@ -1,6 +1,6 @@
 Example where a `<select>` element gets dynamic list
 
-<!-- fiddle -->
+<!-- fiddle Dynamic select -->
 
 ```html
 <select id="my-select"></select>

--- a/cypress/integration/dynamic-select.md
+++ b/cypress/integration/dynamic-select.md
@@ -4,10 +4,25 @@ Example where a `<select>` element gets dynamic list
 
 ```html
 <select id="my-select"></select>
+
+<script>
+  // populate the select element dynamically
+  const s = document.getElementById('my-select')
+  const addOption = (x) => () => {
+    s.innerHTML += `
+      <option value=${x.toLowerCase()}>${x}</option>
+    `
+  }
+  setTimeout(addOption('Alpha'), 500)
+  setTimeout(addOption('Beta'), 1000)
+  setTimeout(addOption('Gamma'), 1500)
+</script>
 ```
 
 ```js
-
+cy.get('#my-select option').should('have.length', 3)
+// now that the select has 3 options, let's pick "Beta"
+cy.get('#my-select').select('beta')
 ```
 
 <!-- fiddle-end -->

--- a/src/index.js
+++ b/src/index.js
@@ -4,9 +4,10 @@
 const { createMarkdown } = require('safe-marked')
 const markdown = createMarkdown()
 
-Cypress.Commands.add('runExample', options => {
+Cypress.Commands.add('runExample', (options) => {
   const { name, description, commonHtml, html, test } = options
-  const testTitle = name ||
+  const testTitle =
+    name ||
     // @ts-ignore
     cy.state('runnable').title
 
@@ -18,7 +19,7 @@ Cypress.Commands.add('runExample', options => {
 
   const fiddleOptions = Cypress._.defaults({}, Cypress.env('cypress-fiddle'), {
     stylesheets: [],
-    style: ''
+    style: '',
   })
 
   let stylesheetsHtml = ''
@@ -26,7 +27,9 @@ Cypress.Commands.add('runExample', options => {
     fiddleOptions.stylesheets = [fiddleOptions.stylesheets]
   }
   if (Array.isArray(fiddleOptions.stylesheets)) {
-    stylesheetsHtml = fiddleOptions.stylesheets.map(url => `<link rel="stylesheet" href="${url}">`).join('\n')
+    stylesheetsHtml = fiddleOptions.stylesheets
+      .map((url) => `<link rel="stylesheet" href="${url}">`)
+      .join('\n')
   }
 
   let style = ''
@@ -107,7 +110,7 @@ Cypress.Commands.add('runExample', options => {
   } else {
     if (html) {
       throw new Error(
-        'You have passed HTML block for this test, but also used cy.visit in the test, which one is it?'
+        'You have passed HTML block for this test, but also used cy.visit in the test, which one is it?',
       )
     }
     // run "full" test
@@ -117,18 +120,18 @@ Cypress.Commands.add('runExample', options => {
 
 const { forEach } = Cypress._
 
-const isTestObject = o => o.test
+const isTestObject = (o) => o.test
 
 const createTest = (name, test) => {
   name = name || test.name
   if (!name) {
-    console.error({ name, test})
+    console.error({ name, test })
     throw new Error('Could not determine test name from ' + name)
   }
 
   if (test.skip && test.only) {
     throw new Error(
-      `Test "${name}" has both skip: true and only: true, which is impossible`
+      `Test "${name}" has both skip: true and only: true, which is impossible`,
     )
   }
 
@@ -157,7 +160,7 @@ const createTest = (name, test) => {
  * Processes a tree of test definitions, each with HTML and JS
  * and makes each into a live test. See examples in "integration" folder.
  */
-const testExamples = maybeTest => {
+const testExamples = (maybeTest) => {
   if (isTestObject(maybeTest)) {
     createTest(maybeTest.name, maybeTest)
     return
@@ -165,7 +168,7 @@ const testExamples = maybeTest => {
 
   if (Array.isArray(maybeTest)) {
     // console.log('list of tests')
-    maybeTest.forEach(test => {
+    maybeTest.forEach((test) => {
       if (isTestObject(test)) {
         createTest(test.name, test)
       } else {
@@ -191,6 +194,12 @@ const testExamples = maybeTest => {
 
     // final choice - create nested suite of tests
     // console.log('creating new suite "%s"', name)
+    if (typeof name !== 'string') {
+      console.error('Invalid test name (typeof %s): "%s"', typeof name, name)
+      console.error({ maybeTest, value, name })
+      throw new Error(`Invalid test name ${name}`)
+    }
+
     describe(name, () => {
       testExamples(value)
     })

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,7 @@ Cypress.Commands.add('runExample', (options) => {
 
 const { forEach } = Cypress._
 
-const isTestObject = (o) => o.test
+const isTestObject = (o) => 'test' in o
 
 const createTest = (name, test) => {
   name = name || test.name
@@ -161,6 +161,9 @@ const createTest = (name, test) => {
  * and makes each into a live test. See examples in "integration" folder.
  */
 const testExamples = (maybeTest) => {
+  // for debugging
+  // console.log('testExamples', { maybeTest })
+
   if (isTestObject(maybeTest)) {
     createTest(maybeTest.name, maybeTest)
     return


### PR DESCRIPTION
- closes #133

also added a Markdown fiddle with a dynamic select element that is populated after a timeout

![dynamic-select](https://user-images.githubusercontent.com/2212006/95370268-855d2700-08a6-11eb-9235-304afbc73883.gif)

```js
cy.get('#my-select option').should('have.length', 3)
// now that the select has 3 options, let's pick "Beta"
cy.get('#my-select').select('beta')
```