### PR TITLE
feat: include 3rd party scripts via an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ The next properties are NOT used by `cy.runExample` but are used by the `testExa
 - [jQuery minified](https://code.jquery.com/)
 - [Highlight.js](https://highlightjs.org/)
 
+You can include your own additional scripts by using environment variable block in `cypress.json` file
+
+```json
+{
+  "env": {
+    "cypress-fiddle": {
+      "scripts": [
+        "https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+      ]
+    }
+  }
+}
+```
+
 ### Styles
 
 Sometimes you want to inject external stylesheets and maybe custom style CSS into the frame (we already include Highlight.js). Pass additional CSS link urls and custom styles through environment variables in `cypress.json` config file.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ If you have common HTML to load before the live HTML block, but do not want to s
     </style>
     -->
 
+You can load styles and external CDN scripts using this approach.
+
 ### Hiding fiddle in Markdown
 
 You can "hide" fiddle inside Markdown so the page _can test itself_. See [cypress/integration/hidden-fiddle.md](cypress/integration/hidden-fiddle.md) example.

--- a/cypress-markdown.json
+++ b/cypress-markdown.json
@@ -1,10 +1,4 @@
 {
   "testFiles": "*.md",
-  "env": {
-    "cypress-fiddle": {
-      "scripts": ["https: //cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"]
-    }
-  },
-  "experimentalSourceRewriting": false,
   "$schema": "https://on.cypress.io/cypress.schema.json"
 }

--- a/cypress-markdown.json
+++ b/cypress-markdown.json
@@ -1,3 +1,10 @@
 {
-  "testFiles": "*.md"
+  "testFiles": "*.md",
+  "env": {
+    "cypress-fiddle": {
+      "scripts": ["https: //cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"]
+    }
+  },
+  "experimentalSourceRewriting": false,
+  "$schema": "https://on.cypress.io/cypress.schema.json"
 }

--- a/cypress/integration/scripts-cdn.md
+++ b/cypress/integration/scripts-cdn.md
@@ -2,7 +2,7 @@
 
 Using "cypress.json" file we can load additional scripts from CDN
 
-<!-- fiddle loads script resource -->
+<!-- fiddle.skip loads script resource -->
 
 ```html
 <div class="alert alert-warning" role="alert">
@@ -11,6 +11,37 @@ Using "cypress.json" file we can load additional scripts from CDN
 ```
 
 ```js
+```
+
+<!-- fiddle-end -->
+
+Or you can include the markup directly in the single test
+
+<!-- fiddle loads script via markup -->
+<!-- fiddle-markup
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx" crossorigin="anonymous"></script>
+-->
+
+```html
+<button type="button"
+  class="btn btn-lg btn-danger"
+  data-toggle="popover"
+  title="Popover title"
+  data-content="Pop!">Click to toggle popover</button>
+<script>
+  // because this fiddle loads bootstrap
+  // it should have popover support
+  $('[data-toggle="popover"]').popover()
+</script>
+```
+
+```js
+cy.get('button').click()
+  .wait(1000)
+// hmm, it is hard to check if the popover
+// is shown because it is created outside
+// of the "#live" container
 ```
 
 <!-- fiddle-end -->

--- a/cypress/integration/scripts-cdn.md
+++ b/cypress/integration/scripts-cdn.md
@@ -1,0 +1,16 @@
+# Scripts from CDN
+
+Using "cypress.json" file we can load additional scripts from CDN
+
+<!-- fiddle loads script resource -->
+
+```html
+<div class="alert alert-warning" role="alert">
+  A simple warning alert—check it out!
+</div>
+```
+
+```js
+```
+
+<!-- fiddle-end -->

--- a/src/index.js
+++ b/src/index.js
@@ -20,15 +20,28 @@ Cypress.Commands.add('runExample', (options) => {
   const fiddleOptions = Cypress._.defaults({}, Cypress.env('cypress-fiddle'), {
     stylesheets: [],
     style: '',
+    scripts: [],
   })
 
+  // take a single stylesheet URL or a list
   let stylesheetsHtml = ''
-  if (typeof fiddleOptions.stylesheets) {
+  if (typeof fiddleOptions.stylesheets === 'string') {
     fiddleOptions.stylesheets = [fiddleOptions.stylesheets]
   }
   if (Array.isArray(fiddleOptions.stylesheets)) {
     stylesheetsHtml = fiddleOptions.stylesheets
       .map((url) => `<link rel="stylesheet" href="${url}">`)
+      .join('\n')
+  }
+
+  // take a single script URL or a list
+  let scriptsHtml = ''
+  if (typeof fiddleOptions.scripts === 'string') {
+    fiddleOptions.scripts = [fiddleOptions.scripts]
+  }
+  if (Array.isArray(fiddleOptions.scripts)) {
+    scriptsHtml = fiddleOptions.scripts
+      .map((url) => `<script src="${url}"></script>`)
       .join('\n')
   }
 
@@ -69,6 +82,7 @@ Cypress.Commands.add('runExample', (options) => {
         crossorigin="anonymous"></script>
       <script charset="UTF-8" src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.9/highlight.min.js"></script>
       <script>hljs.initHighlightingOnLoad();</script>
+      ${scriptsHtml}
     </head>
     <body>
       ${testTitle ? `<h1>${testTitle}</h1>` : ''}


### PR DESCRIPTION
closes #142 

Either using `scripts` env variable or by including in the `fiddle-markup` comment